### PR TITLE
Litle: Update schema version to 12.3 and test correction

### DIFF
--- a/test/remote/gateways/remote_litle_test.rb
+++ b/test/remote/gateways/remote_litle_test.rb
@@ -31,10 +31,10 @@ class RemoteLitleTest < Test::Unit::TestCase
     @credit_card2 = CreditCard.new(
       first_name: 'Joe',
       last_name: 'Green',
-      month: '06',
-      year: '2012',
+      month: '12',
+      year: '2020',
       brand: 'visa',
-      number: '4457010100000008',
+      number: '4457002100000110',
       verification_value: '992'
     )
     @credit_card_nsf = CreditCard.new(
@@ -143,9 +143,15 @@ class RemoteLitleTest < Test::Unit::TestCase
     assert_equal 'Approved', response.message
   end
 
-  def test_avs_and_cvv_result
+  def test_avs_result
+    @credit_card1.number = 4100401234567000
     assert response = @gateway.authorize(10010, @credit_card1, @options)
     assert_equal 'X', response.avs_result['code']
+  end
+
+  def test_cvv_result
+    @credit_card1.number = 4100501234567000
+    assert response = @gateway.authorize(10010, @credit_card1, @options)
     assert_equal 'M', response.cvv_result['code']
   end
 
@@ -218,19 +224,19 @@ class RemoteLitleTest < Test::Unit::TestCase
   end
 
   def test_successful_purchase_with_apple_pay
-    assert response = @gateway.purchase(10010, @decrypted_apple_pay)
+    assert response = @gateway.purchase(1000, @decrypted_apple_pay, @options)
     assert_success response
     assert_equal 'Approved', response.message
   end
 
   def test_successful_purchase_with_android_pay
-    assert response = @gateway.purchase(10000, @decrypted_android_pay)
+    assert response = @gateway.purchase(10000, @decrypted_android_pay, @options)
     assert_success response
     assert_equal 'Approved', response.message
   end
 
   def test_successful_purchase_with_google_pay
-    assert response = @gateway.purchase(10000, @decrypted_google_pay)
+    assert response = @gateway.purchase(10000, @decrypted_google_pay, @options)
     assert_success response
     assert_equal 'Approved', response.message
   end
@@ -273,26 +279,27 @@ class RemoteLitleTest < Test::Unit::TestCase
   end
 
   def test_authorize_capture_refund_void
+    @credit_card1.number = '4457010000000000'
     assert auth = @gateway.authorize(10010, @credit_card1, @options)
     assert_success auth
     assert_equal 'Approved', auth.message
 
-    assert capture = @gateway.capture(nil, auth.authorization)
+    assert capture = @gateway.capture(nil, auth.authorization, @options)
     assert_success capture
     assert_equal 'Approved', capture.message
 
-    assert refund = @gateway.refund(nil, capture.authorization)
+    assert refund = @gateway.refund(nil, capture.authorization, @options)
     assert_success refund
     assert_equal 'Approved', refund.message
 
-    assert void = @gateway.void(refund.authorization)
+    assert void = @gateway.void(refund.authorization, @options)
     assert_success void
     assert_equal 'Approved', void.message
   end
 
   def test_authorize_and_capture_with_stored_credential_recurring
     credit_card = CreditCard.new(@credit_card_hash.merge(
-                                   number: '4100200300011001',
+                                   number: '4100200300011000',
                                    month: '05',
                                    year: '2021',
                                    verification_value: '463'
@@ -312,7 +319,7 @@ class RemoteLitleTest < Test::Unit::TestCase
     assert_equal 'Approved', auth.message
     assert network_transaction_id = auth.params['networkTransactionId']
 
-    assert capture = @gateway.capture(4999, auth.authorization)
+    assert capture = @gateway.capture(4999, auth.authorization, initial_options)
     assert_success capture
     assert_equal 'Approved', capture.message
 
@@ -329,7 +336,7 @@ class RemoteLitleTest < Test::Unit::TestCase
     assert_success auth
     assert_equal 'Approved', auth.message
 
-    assert capture = @gateway.capture(4999, auth.authorization)
+    assert capture = @gateway.capture(4999, auth.authorization, used_options)
     assert_success capture
     assert_equal 'Approved', capture.message
   end
@@ -356,7 +363,7 @@ class RemoteLitleTest < Test::Unit::TestCase
     assert_equal 'Approved', auth.message
     assert network_transaction_id = auth.params['networkTransactionId']
 
-    assert capture = @gateway.capture(5500, auth.authorization)
+    assert capture = @gateway.capture(5500, auth.authorization, initial_options)
     assert_success capture
     assert_equal 'Approved', capture.message
 
@@ -373,7 +380,7 @@ class RemoteLitleTest < Test::Unit::TestCase
     assert_success auth
     assert_equal 'Approved', auth.message
 
-    assert capture = @gateway.capture(5500, auth.authorization)
+    assert capture = @gateway.capture(5500, auth.authorization, used_options)
     assert_success capture
     assert_equal 'Approved', capture.message
   end
@@ -399,8 +406,7 @@ class RemoteLitleTest < Test::Unit::TestCase
     assert_success auth
     assert_equal 'Approved', auth.message
     assert network_transaction_id = auth.params['networkTransactionId']
-
-    assert capture = @gateway.capture(5500, auth.authorization)
+    assert capture = @gateway.capture(5500, auth.authorization, initial_options)
     assert_success capture
     assert_equal 'Approved', capture.message
 
@@ -417,7 +423,7 @@ class RemoteLitleTest < Test::Unit::TestCase
     assert_success auth
     assert_equal 'Approved', auth.message
 
-    assert capture = @gateway.capture(2500, auth.authorization)
+    assert capture = @gateway.capture(2500, auth.authorization, used_options)
     assert_success capture
     assert_equal 'Approved', capture.message
   end
@@ -439,12 +445,12 @@ class RemoteLitleTest < Test::Unit::TestCase
         network_transaction_id: nil
       }
     )
+
     assert auth = @gateway.authorize(5500, credit_card, initial_options)
     assert_success auth
     assert_equal 'Approved', auth.message
     assert network_transaction_id = auth.params['networkTransactionId']
-
-    assert capture = @gateway.capture(5500, auth.authorization)
+    assert capture = @gateway.capture(5500, auth.authorization, initial_options)
     assert_success capture
     assert_equal 'Approved', capture.message
 
@@ -460,8 +466,7 @@ class RemoteLitleTest < Test::Unit::TestCase
     assert auth = @gateway.authorize(4000, credit_card, used_options)
     assert_success auth
     assert_equal 'Approved', auth.message
-
-    assert capture = @gateway.capture(4000, auth.authorization)
+    assert capture = @gateway.capture(4000, auth.authorization, used_options)
     assert_success capture
     assert_equal 'Approved', capture.message
   end
@@ -515,21 +520,20 @@ class RemoteLitleTest < Test::Unit::TestCase
     })
     assert sale = @gateway.purchase(2004, @check, options)
 
-    assert void = @gateway.void(sale.authorization)
+    assert void = @gateway.void(sale.authorization, options)
     assert_success void
     assert_equal 'Approved', void.message
   end
 
   def test_void_authorization
     assert auth = @gateway.authorize(10010, @credit_card1, @options)
-
-    assert void = @gateway.void(auth.authorization)
+    assert void = @gateway.void(auth.authorization, @options)
     assert_success void
     assert_equal 'Approved', void.message
   end
 
   def test_unsuccessful_void
-    assert void = @gateway.void('123456789012345360;authorization;100')
+    assert void = @gateway.void('123456789012345360;authorization;1000', @options)
     assert_failure void
     assert_equal 'No transaction found with specified Transaction Id', void.message
   end
@@ -548,8 +552,7 @@ class RemoteLitleTest < Test::Unit::TestCase
 
   def test_partial_refund
     assert purchase = @gateway.purchase(10010, @credit_card1, @options)
-
-    assert refund = @gateway.refund(444, purchase.authorization)
+    assert refund = @gateway.refund(444, purchase.authorization, @options)
     assert_success refund
     assert_equal 'Approved', refund.message
   end
@@ -561,7 +564,7 @@ class RemoteLitleTest < Test::Unit::TestCase
     })
     assert purchase = @gateway.purchase(2004, @check, options)
 
-    assert refund = @gateway.refund(444, purchase.authorization)
+    assert refund = @gateway.refund(444, purchase.authorization, options)
     assert_success refund
     assert_equal 'Approved', refund.message
   end
@@ -571,7 +574,7 @@ class RemoteLitleTest < Test::Unit::TestCase
     assert_success auth
     assert_equal 'Approved', auth.message
 
-    assert capture = @gateway.capture(5005, auth.authorization)
+    assert capture = @gateway.capture(5005, auth.authorization, @options)
     assert_success capture
     assert_equal 'Approved', capture.message
   end
@@ -581,7 +584,7 @@ class RemoteLitleTest < Test::Unit::TestCase
     assert_success auth
     assert_equal 'Approved', auth.message
 
-    assert capture = @gateway.capture(10010, auth.authorization)
+    assert capture = @gateway.capture(10010, auth.authorization, @options)
     assert_success capture
     assert_equal 'Approved', capture.message
   end
@@ -591,39 +594,39 @@ class RemoteLitleTest < Test::Unit::TestCase
     assert_success auth
     assert_equal 'Approved', auth.message
 
-    assert capture = @gateway.capture(nil, auth.authorization)
+    assert capture = @gateway.capture(nil, auth.authorization, @options)
     assert_success capture
     assert_equal 'Approved', capture.message
   end
 
   def test_capture_unsuccessful
-    assert capture_response = @gateway.capture(10010, '123456789012345360')
+    assert capture_response = @gateway.capture(6000, '4488282659650360', @options)
     assert_failure capture_response
     assert_equal 'No transaction found with specified Transaction Id', capture_response.message
   end
 
   def test_refund_unsuccessful
-    assert credit_response = @gateway.refund(10010, '123456789012345360')
+    assert credit_response = @gateway.refund(10010, '123456789012345360', order_id: '360')
     assert_failure credit_response
     assert_equal 'No transaction found with specified Transaction Id', credit_response.message
   end
 
   def test_void_unsuccessful
-    assert void_response = @gateway.void('123456789012345360')
+    assert void_response = @gateway.void('123456789012345360', @options)
     assert_failure void_response
     assert_equal 'No transaction found with specified Transaction Id', void_response.message
   end
 
   def test_store_successful
     credit_card = CreditCard.new(@credit_card_hash.merge(number: '4457119922390123'))
-    assert store_response = @gateway.store(credit_card, order_id: '50')
+    assert store_response = @gateway.store(credit_card, { order_id: '50', merchant: 'RG1' })
 
     assert_success store_response
     assert_equal 'Account number was successfully registered', store_response.message
     assert_equal '445711', store_response.params['bin']
     assert_equal 'VI', store_response.params['type']
     assert_equal '801', store_response.params['response']
-    assert_equal '1111222233330123', store_response.params['litleToken']
+    assert_equal '1111222233334444', store_response.params['cnpToken']
   end
 
   def test_store_with_paypage_registration_id_successful
@@ -633,15 +636,15 @@ class RemoteLitleTest < Test::Unit::TestCase
     assert_success store_response
     assert_equal 'Account number was successfully registered', store_response.message
     assert_equal '801', store_response.params['response']
-    assert_equal '1111222233334444', store_response.params['litleToken']
+    assert_equal '1111222233334444', store_response.params['cnpToken']
   end
 
   def test_store_unsuccessful
-    credit_card = CreditCard.new(@credit_card_hash.merge(number: '4457119999999999'))
+    credit_card = CreditCard.new(@credit_card_hash.merge(number: '4100282040123000'))
     assert store_response = @gateway.store(credit_card, order_id: '51')
 
     assert_failure store_response
-    assert_equal 'Credit card number was invalid', store_response.message
+    assert_equal 'Credit card Number was invalid', store_response.message
     assert_equal '820', store_response.params['response']
   end
 
@@ -651,9 +654,9 @@ class RemoteLitleTest < Test::Unit::TestCase
     assert_success store_response
 
     token = store_response.authorization
-    assert_equal store_response.params['litleToken'], token
+    assert_equal store_response.params['cnpToken'], token
 
-    assert response = @gateway.purchase(10010, token)
+    assert response = @gateway.purchase(1000, token, @options)
     assert_success response
     assert_equal 'Approved', response.message
   end
@@ -663,22 +666,22 @@ class RemoteLitleTest < Test::Unit::TestCase
     assert_success store_response
 
     token = store_response.authorization
-    assert_equal store_response.params['litleToken'], token
+    assert_equal store_response.params['cnpToken'], token
 
-    assert response = @gateway.purchase(10010, token, { basis_expiration_month: '01', basis_expiration_year: '2024' })
+    assert response = @gateway.purchase(1000, token, { basis_expiration_month: '01', basis_expiration_year: '2024', order_id: '50' })
     assert_success response
     assert_equal 'Approved', response.message
   end
 
   def test_echeck_store_and_purchase
-    assert store_response = @gateway.store(@store_check)
+    assert store_response = @gateway.store(@store_check, @options)
     assert_success store_response
     assert_equal 'Account number was successfully registered', store_response.message
 
     token = store_response.authorization
-    assert_equal store_response.params['litleToken'], token
+    assert_equal store_response.params['cnpToken'], token
 
-    assert response = @gateway.purchase(10010, token)
+    assert response = @gateway.purchase(1000, token, @options)
     assert_success response
     assert_equal 'Approved', response.message
   end

--- a/test/unit/gateways/litle_test.rb
+++ b/test/unit/gateways/litle_test.rb
@@ -337,7 +337,7 @@ class LitleTest < Test::Unit::TestCase
     end.respond_with(failed_refund_response)
 
     assert_failure response
-    assert_equal 'No transaction found with specified litleTxnId', response.message
+    assert_equal 'No transaction found with specified transaction Id', response.message
     assert_equal '360', response.params['response']
   end
 
@@ -369,7 +369,7 @@ class LitleTest < Test::Unit::TestCase
     void = stub_comms do
       @gateway.void(response.authorization)
     end.check_request do |_endpoint, data, _headers|
-      assert_match(/<authReversal.*<litleTxnId>100000000000000001</m, data)
+      assert_match(/<authReversal.*<cnpTxnId>100000000000000001</m, data)
     end.respond_with(successful_void_of_auth_response)
 
     assert_success void
@@ -385,7 +385,7 @@ class LitleTest < Test::Unit::TestCase
     void = stub_comms do
       @gateway.void(refund.authorization)
     end.check_request do |_endpoint, data, _headers|
-      assert_match(/<void.*<litleTxnId>100000000000000003</m, data)
+      assert_match(/<void.*<cnpTxnId>100000000000000003</m, data)
     end.respond_with(successful_void_of_other_things_response)
 
     assert_success void
@@ -710,9 +710,9 @@ class LitleTest < Test::Unit::TestCase
 
   def successful_purchase_response
     %(
-      <litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
+      <cnpOnlineResponse xmlns="http://www.vantivcnp.com/schema" version="12.8" response="0" message="Valid Format">
         <saleResponse id='1' reportGroup='Default Report Group' customerId=''>
-          <litleTxnId>100000000000000006</litleTxnId>
+          <cnpTxnId>100000000000000006</cnpTxnId>
           <orderId>1</orderId>
           <response>000</response>
           <responseTime>2014-03-31T11:34:39</responseTime>
@@ -723,29 +723,29 @@ class LitleTest < Test::Unit::TestCase
             <cardValidationResult>M</cardValidationResult>
           </fraudResult>
         </saleResponse>
-      </litleOnlineResponse>
+      </cnpOnlineResponse>
     )
   end
 
   def successful_purchase_with_echeck_response
     %(
-      <litleOnlineResponse version='9.12' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
+      <cnpOnlineResponse xmlns="http://www.vantivcnp.com/schema" version="12.8" response="0" message="Valid Format">
         <echeckSalesResponse id='42' reportGroup='Default Report Group' customerId=''>
-          <litleTxnId>621100411297330000</litleTxnId>
+          <cnpTxnId>621100411297330000</cnpTxnId>
           <orderId>42</orderId>
           <response>000</response>
           <responseTime>2018-01-09T14:02:20</responseTime>
           <message>Approved</message>
         </echeckSalesResponse>
-      </litleOnlineResponse>
+      </cnpOnlineResponse>
     )
   end
 
   def successful_authorize_stored_credentials
     %(
-      <litleOnlineResponse xmlns="http://www.litle.com/schema" version="9.14" response="0" message="Valid Format">
+      <cnpOnlineResponse xmlns="http://www.vantivcnp.com/schema" version="12.8" response="0" message="Valid Format">
         <authorizationResponse id="1" reportGroup="Default Report Group">
-          <litleTxnId>991939023768015826</litleTxnId>
+          <cnpTxnId>991939023768015826</cnpTxnId>
           <orderId>1</orderId>
           <response>000</response>
           <message>Approved</message>
@@ -753,15 +753,15 @@ class LitleTest < Test::Unit::TestCase
           <authCode>75045</authCode>
           <networkTransactionId>63225578415568556365452427825</networkTransactionId>
         </authorizationResponse>
-      </litleOnlineResponse>
+      </cnpOnlineResponse>
     )
   end
 
   def failed_purchase_response
     %(
-      <litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
+      <cnpOnlineResponse xmlns="http://www.vantivcnp.com/schema" version="12.8" response="0" message="Valid Format">
         <saleResponse id='6' reportGroup='Default Report Group' customerId=''>
-          <litleTxnId>600000000000000002</litleTxnId>
+          <cnpTxnId>600000000000000002</cnpTxnId>
           <orderId>6</orderId>
           <response>110</response>
           <responseTime>2014-03-31T11:48:47</responseTime>
@@ -771,15 +771,15 @@ class LitleTest < Test::Unit::TestCase
             <cardValidationResult>P</cardValidationResult>
           </fraudResult>
         </saleResponse>
-      </litleOnlineResponse>
+      </cnpOnlineResponse>
     )
   end
 
   def successful_authorize_response
     %(
-      <litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
+      <cnpOnlineResponse xmlns="http://www.vantivcnp.com/schema" version="12.8" response="0" message="Valid Format">
         <authorizationResponse id='1' reportGroup='Default Report Group' customerId=''>
-          <litleTxnId>100000000000000001</litleTxnId>
+          <cnpTxnId>100000000000000001</cnpTxnId>
           <orderId>1</orderId>
           <response>000</response>
           <responseTime>2014-03-31T12:21:56</responseTime>
@@ -790,15 +790,15 @@ class LitleTest < Test::Unit::TestCase
             <cardValidationResult>M</cardValidationResult>
           </fraudResult>
         </authorizationResponse>
-      </litleOnlineResponse>
+      </cnpOnlineResponse>
     )
   end
 
   def failed_authorize_response
     %(
-      <litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
+      <cnpOnlineResponse xmlns="http://www.vantivcnp.com/schema" version="12.8" response="0" message="Valid Format">
         <authorizationResponse id='6' reportGroup='Default Report Group' customerId=''>
-          <litleTxnId>600000000000000001</litleTxnId>
+          <cnpTxnId>600000000000000001</cnpTxnId>
           <orderId>6</orderId>
           <response>110</response>
           <responseTime>2014-03-31T12:24:21</responseTime>
@@ -808,201 +808,201 @@ class LitleTest < Test::Unit::TestCase
             <cardValidationResult>P</cardValidationResult>
           </fraudResult>
         </authorizationResponse>
-      </litleOnlineResponse>
+      </cnpOnlineResponse>
     )
   end
 
   def successful_capture_response
     %(
-      <litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
+      <cnpOnlineResponse xmlns="http://www.vantivcnp.com/schema" version="12.8" response="0" message="Valid Format">
         <captureResponse id='' reportGroup='Default Report Group' customerId=''>
-          <litleTxnId>100000000000000002</litleTxnId>
+          <cnpTxnId>100000000000000002</cnpTxnId>
           <response>000</response>
           <responseTime>2014-03-31T12:28:07</responseTime>
           <message>Approved</message>
         </captureResponse>
-      </litleOnlineResponse>
+      </cnpOnlineResponse>
     )
   end
 
   def failed_capture_response
     %(
-      <litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
+      <cnpOnlineResponse xmlns="http://www.vantivcnp.com/schema" version="12.8" response="0" message="Valid Format">
         <captureResponse id='' reportGroup='Default Report Group' customerId=''>
-          <litleTxnId>304546900824606360</litleTxnId>
+          <cnpTxnId>304546900824606360</cnpTxnId>
           <response>360</response>
           <responseTime>2014-03-31T12:30:53</responseTime>
           <message>No transaction found with specified litleTxnId</message>
         </captureResponse>
-      </litleOnlineResponse>
+      </cnpOnlineResponse>
     )
   end
 
   def successful_refund_response
     %(
-      <litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
+      <cnpOnlineResponse xmlns="http://www.vantivcnp.com/schema" version="12.8" response="0" message="Valid Format">
         <creditResponse id='' reportGroup='Default Report Group' customerId=''>
-          <litleTxnId>100000000000000003</litleTxnId>
+          <cnpTxnId>100000000000000003</cnpTxnId>
           <response>000</response>
           <responseTime>2014-03-31T12:36:50</responseTime>
           <message>Approved</message>
         </creditResponse>
-      </litleOnlineResponse>
+      </cnpOnlineResponse>
     )
   end
 
   def failed_refund_response
     %(
-      <litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
+      <cnpOnlineResponse xmlns="http://www.vantivcnp.com/schema" version="12.8" response="0" message="Valid Format">
         <creditResponse id='' reportGroup='Default Report Group' customerId=''>
-          <litleTxnId>996483567570258360</litleTxnId>
+          <cnpTxnId>996483567570258360</cnpTxnId>
           <response>360</response>
           <responseTime>2014-03-31T12:42:41</responseTime>
-          <message>No transaction found with specified litleTxnId</message>
+          <message>No transaction found with specified transaction Id</message>
         </creditResponse>
-      </litleOnlineResponse>
+      </cnpOnlineResponse>
     )
   end
 
   def successful_credit_response
     %(
       <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-      <litleOnlineResponse version="9.14" response="0" message="Valid Format">
+      <cnpOnlineResponse xmlns="http://www.vantivcnp.com/schema" version="12.8" response="0" message="Valid Format">
         <creditResponse id="1" reportGroup="Default Report Group">
-          <litleTxnId>908410935514139173</litleTxnId>
+          <cnpTxnId>908410935514139173</cnpTxnId>
           <orderId>1</orderId>
           <response>000</response>
           <responseTime>2020-10-30T19:19:38.935</responseTime>
           <message>Approved</message>
         </creditResponse>
-      </litleOnlineResponse>
+      </cnpOnlineResponse>
     )
   end
 
   def failed_credit_response
     %(
       <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-      <litleOnlineResponse version="9.14" response="1" message="Error validating xml data against the schema: cvc-minLength-valid: Value '1234567890' with length = '10' is not facet-valid with respect to minLength '13' for type 'ccAccountNumberType'."/>
+      <cnpOnlineResponse version="12.8" response="1" message="Error validating xml data against the schema: cvc-minLength-valid: Value '1234567890' with length = '10' is not facet-valid with respect to minLength '13' for type 'ccAccountNumberType'."/>
     )
   end
 
   def successful_void_of_auth_response
     %(
-      <litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
+      <cnpOnlineResponse xmlns="http://www.vantivcnp.com/schema" version="12.8" response="0" message="Valid Format">
         <authReversalResponse id='' reportGroup='Default Report Group' customerId=''>
-          <litleTxnId>972619753208653000</litleTxnId>
+          <cnpTxnId>972619753208653000</cnpTxnId>
           <orderId>123</orderId>
           <response>000</response>
           <responseTime>2014-03-31T12:45:44</responseTime>
           <message>Approved</message>
         </authReversalResponse>
-      </litleOnlineResponse>
+      </cnpOnlineResponse>
     )
   end
 
   def successful_void_of_other_things_response
     %(
-      <litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
+      <cnpOnlineResponse xmlns="http://www.vantivcnp.com/schema" version="12.8" response="0" message="Valid Format">
         <voidResponse id='' reportGroup='Default Report Group' customerId=''>
-          <litleTxnId>100000000000000004</litleTxnId>
+          <cnpTxnId>100000000000000004</cnpTxnId>
           <response>000</response>
           <responseTime>2014-03-31T12:44:52</responseTime>
           <message>Approved</message>
         </voidResponse>
-      </litleOnlineResponse>
+      </cnpOnlineResponse>
     )
   end
 
   def successful_void_of_echeck_response
     %(
-      <litleOnlineResponse version='9.12' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
+      <cnpOnlineResponse xmlns="http://www.vantivcnp.com/schema" version="12.8" response="0" message="Valid Format">
         <echeckVoidResponse id='' reportGroup='Default Report Group' customerId=''>
-          <litleTxnId>986272331806746000</litleTxnId>
+          <cnpTxnId>986272331806746000</cnpTxnId>
           <response>000</response>
           <responseTime>2018-01-09T14:20:00</responseTime>
           <message>Approved</message>
           <postDate>2018-01-09</postDate>
         </echeckVoidResponse>
-      </litleOnlineResponse>
+      </cnpOnlineResponse>
     )
   end
 
   def failed_void_of_authorization_response
     %(
-      <litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
+      <cnpOnlineResponse xmlns="http://www.vantivcnp.com/schema" version="12.8" response="0" message="Valid Format">
         <authReversalResponse id='' reportGroup='Default Report Group' customerId=''>
-          <litleTxnId>775712323632364360</litleTxnId>
+          <cnpTxnId>775712323632364360</cnpTxnId>
           <orderId>123</orderId>
           <response>360</response>
           <responseTime>2014-03-31T13:03:17</responseTime>
           <message>No transaction found with specified litleTxnId</message>
         </authReversalResponse>
-      </litleOnlineResponse>
+      </cnpOnlineResponse>
     )
   end
 
   def failed_void_of_other_things_response
     %(
-      <litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
+      <cnpOnlineResponse xmlns="http://www.vantivcnp.com/schema" version="12.8" response="0" message="Valid Format">
         <voidResponse id='' reportGroup='Default Report Group' customerId=''>
-          <litleTxnId>486912375928374360</litleTxnId>
+          <cnpTxnId>486912375928374360</cnpTxnId>
           <response>360</response>
           <responseTime>2014-03-31T12:55:46</responseTime>
           <message>No transaction found with specified litleTxnId</message>
         </voidResponse>
-      </litleOnlineResponse>
+      </cnpOnlineResponse>
     )
   end
 
   def successful_store_response
     %(
-      <litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
+      <cnpOnlineResponse xmlns="http://www.vantivcnp.com/schema" version="12.8" response="0" message="Valid Format">
         <registerTokenResponse id='50' reportGroup='Default Report Group' customerId=''>
-          <litleTxnId>501000000000000001</litleTxnId>
+          <cnpTxnId>501000000000000001</cnpTxnId>
           <orderId>50</orderId>
-          <litleToken>1111222233330123</litleToken>
+          <cnpToken>1111222233330123</cnpToken>
           <response>801</response>
           <responseTime>2014-03-31T13:06:41</responseTime>
           <message>Account number was successfully registered</message>
           <bin>445711</bin>
           <type>VI</type>
         </registerTokenResponse>
-      </litleOnlineResponse>
+      </cnpOnlineResponse>
     )
   end
 
   def successful_store_paypage_response
     %(
-      <litleOnlineResponse version='8.2' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
+      <cnpOnlineResponse xmlns="http://www.vantivcnp.com/schema" version="12.8" response="0" message="Valid Format">
         <registerTokenResponse id='99999' reportGroup='Default Report Group' customerId=''>
-          <litleTxnId>222358384397377801</litleTxnId>
+          <cnpTxnId>222358384397377801</cnpTxnId>
           <orderId>F12345</orderId>
-          <litleToken>1111222233334444</litleToken>
+          <cnpToken>1111222233334444</cnpToken>
           <response>801</response>
           <responseTime>2015-05-20T14:37:22</responseTime>
           <message>Account number was successfully registered</message>
         </registerTokenResponse>
-      </litleOnlineResponse>
+      </cnpOnlineResponse>
     )
   end
 
   def failed_store_response
     %(
-      <litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
+      <cnpOnlineResponse xmlns="http://www.vantivcnp.com/schema" version="12.8" response="0" message="Valid Format">
         <registerTokenResponse id='51' reportGroup='Default Report Group' customerId=''>
-          <litleTxnId>510000000000000001</litleTxnId>
+          <cnpTxnId>510000000000000001</cnpTxnId>
           <orderId>51</orderId>
           <response>820</response>
           <responseTime>2014-03-31T13:10:51</responseTime>
           <message>Credit card number was invalid</message>
         </registerTokenResponse>
-      </litleOnlineResponse>
+      </cnpOnlineResponse>
     )
   end
 
   def unsuccessful_xml_schema_validation_response
     %(
-    <litleOnlineResponse version='8.29' xmlns='http://www.litle.com/schema'
+    <cnpOnlineResponse version='12.8' xmlns='http://www.vantivcnp.com/schema'
                      response='1'
                      message='Error validating xml data against the schema on line 8\nthe length of the value is 10, but the required minimum is 13.'/>
 
@@ -1016,7 +1016,7 @@ class LitleTest < Test::Unit::TestCase
       starting SSL for www.testlitle.com:443...
       SSL established
       <- "POST /sandbox/communicator/online HTTP/1.1\r\nContent-Type: text/xml\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nConnection: close\r\nHost: www.testlitle.com\r\nContent-Length: 406\r\n\r\n"
-      <- "<litleOnlineRequest xmlns=\"http://www.litle.com/schema\" merchantId=\"101\" version=\"9.4\">\n  <authentication>\n    <user>ACTIVE</user>\n    <password>MERCHANT</password>\n  </authentication>\n  <registerTokenRequest reportGroup=\"Default Report Group\">\n    <orderId/>\n    <accountNumber>4242424242424242</accountNumber>\n    <cardValidationNum>111</cardValidationNum>\n  </registerTokenRequest>\n</litleOnlineRequest>"
+      <- "<cnpOnlineRequest xmlns=\"http://www.vantivcnp.com/schema\" merchantId=\"101\" version=\"12.8\">\n  <authentication>\n    <user>ACTIVE</user>\n    <password>MERCHANT</password>\n  </authentication>\n  <registerTokenRequest reportGroup=\"Default Report Group\">\n    <orderId/>\n    <accountNumber>4242424242424242</accountNumber>\n    <cardValidationNum>111</cardValidationNum>\n  </registerTokenRequest>\n</cnpOnlineRequest>"
       -> "HTTP/1.1 200 OK\r\n"
       -> "Date: Mon, 16 May 2016 03:07:36 GMT\r\n"
       -> "Server: Apache-Coyote/1.1\r\n"
@@ -1027,7 +1027,7 @@ class LitleTest < Test::Unit::TestCase
       -> "1bf\r\n"
       reading 447 bytes...
       -> ""
-      -> "<litleOnlineResponse version='10.1' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>\n  <registerTokenResponse id='' reportGroup='Default Report Group' customerId=''>\n    <litleTxnId>185074924759529000</litleTxnId>\n    <litleToken>1111222233334444</litleToken>\n    <response>000</response>\n    <responseTime>2016-05-15T23:07:36</responseTime>\n    <message>Approved</message>\n  </registerTokenResponse>\n</litleOnlineResponse>"
+      -> "<cnpOnlineResponse version='12.8' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'>\n  <registerTokenResponse id='' reportGroup='Default Report Group' customerId=''>\n    <cnpTxnId>185074924759529000</cnpTxnId>\n    <cnpToken>1111222233334444</cnpToken>\n    <response>000</response>\n    <responseTime>2016-05-15T23:07:36</responseTime>\n    <message>Approved</message>\n  </registerTokenResponse>\n</cnpOnlineResponse>"
       read 447 bytes
       reading 2 bytes...
       -> ""
@@ -1046,7 +1046,7 @@ class LitleTest < Test::Unit::TestCase
       starting SSL for www.testlitle.com:443...
       SSL established
       <- "POST /sandbox/communicator/online HTTP/1.1\r\nContent-Type: text/xml\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nConnection: close\r\nHost: www.testlitle.com\r\nContent-Length: 406\r\n\r\n"
-      <- "<litleOnlineRequest xmlns=\"http://www.litle.com/schema\" merchantId=\"101\" version=\"9.4\">\n  <authentication>\n    <user>[FILTERED]</user>\n    <password>[FILTERED]</password>\n  </authentication>\n  <registerTokenRequest reportGroup=\"Default Report Group\">\n    <orderId/>\n    <accountNumber>[FILTERED]</accountNumber>\n    <cardValidationNum>[FILTERED]</cardValidationNum>\n  </registerTokenRequest>\n</litleOnlineRequest>"
+      <- "<cnpOnlineRequest xmlns=\"http://www.vantivcnp.com/schema\" merchantId=\"101\" version=\"12.8\">\n  <authentication>\n    <user>[FILTERED]</user>\n    <password>[FILTERED]</password>\n  </authentication>\n  <registerTokenRequest reportGroup=\"Default Report Group\">\n    <orderId/>\n    <accountNumber>[FILTERED]</accountNumber>\n    <cardValidationNum>[FILTERED]</cardValidationNum>\n  </registerTokenRequest>\n</cnpOnlineRequest>"
       -> "HTTP/1.1 200 OK\r\n"
       -> "Date: Mon, 16 May 2016 03:07:36 GMT\r\n"
       -> "Server: Apache-Coyote/1.1\r\n"
@@ -1057,7 +1057,7 @@ class LitleTest < Test::Unit::TestCase
       -> "1bf\r\n"
       reading 447 bytes...
       -> ""
-      -> "<litleOnlineResponse version='10.1' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>\n  <registerTokenResponse id='' reportGroup='Default Report Group' customerId=''>\n    <litleTxnId>185074924759529000</litleTxnId>\n    <litleToken>1111222233334444</litleToken>\n    <response>000</response>\n    <responseTime>2016-05-15T23:07:36</responseTime>\n    <message>Approved</message>\n  </registerTokenResponse>\n</litleOnlineResponse>"
+      -> "<cnpOnlineResponse version='12.8' response='0' message='Valid Format' xmlns='http://www.vantivcnp.com/schema'>\n  <registerTokenResponse id='' reportGroup='Default Report Group' customerId=''>\n    <cnpTxnId>185074924759529000</cnpTxnId>\n    <cnpToken>1111222233334444</cnpToken>\n    <response>000</response>\n    <responseTime>2016-05-15T23:07:36</responseTime>\n    <message>Approved</message>\n  </registerTokenResponse>\n</cnpOnlineResponse>"
       read 447 bytes
       reading 2 bytes...
       -> ""


### PR DESCRIPTION
--------
Summary:
This PR updates the used schema to the latest version available according to the docs on https://vantiv.github.io/latest-versions/

Test Execution:
Finished in 38.911867 seconds.
50 tests, 227 assertions, 4 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
92% passed
Several failing tests corrected according to docs in the following pages:
https://vantiv.github.io/sandbox/#howItWorks
https://developer.worldpay.com/assets/pdf/us-ecom-pdf/Worldpay_eComm_cnpAPI_Reference_Guide_APIV12.12_V2.16.pdf

RuboCop:
728 files inspected, no offenses detected